### PR TITLE
Windows instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ FIXME: I'm not sure if you have to install the packages `mingw-w64-x86_64-toolch
 
 Now you can start FAHControl:
 
+    python setup.py build
     python FAHControl
 
 Optionally install for development / building:
@@ -38,5 +39,6 @@ Optionally install for development / building:
 
 For building an executable:
 
+    python setup.py build
     pip install pyinstaller
     pyinstaller FAHControl --windowed

--- a/README.md
+++ b/README.md
@@ -18,3 +18,25 @@ See: https://foldingathome.org/
 ## RedHat / CentOS
 
     sudo yum install -y pygtk2
+
+## Windows 10 / MSYS2
+
+Basically follow https://www.gtk.org/docs/installations/windows/#using-gtk-from-msys2-packages and the instructions on https://www.msys2.org/
+
+    pacman -Syuu
+    pacman -S mingw-w64-x86_64-python3 mingw-w64-x86_64-gtk3 mingw-w64-x86_64-python3-gobject
+
+FIXME: I'm not sure if you have to install the packages `mingw-w64-x86_64-toolchain base-devel` as well.
+
+Now you can start FAHControl:
+
+    python FAHControl
+
+Optionally install for development / building:
+
+    pacman -S mingw-w64-x86_64-python3-pip mingw-w64-x86_64-glade mingw-w64-x86_64-python3-pytest
+
+For building an executable:
+
+    pip install pyinstaller
+    pyinstaller FAHControl --windowed

--- a/fah/FAHControl.py
+++ b/fah/FAHControl.py
@@ -200,7 +200,7 @@ class FAHControl(SingleAppServer):
         Gtk.Window.set_default_icon(get_icon('small'))
 
         # Filter glade
-        if len(glade) < 1024: glade = open(glade, 'r').read()
+        if len(glade) < 1024: glade = open(glade, 'r', encoding = "utf8").read()
         glade = re.subn('class="GtkLabel" id="wlabel',
                         'class="WrapLabel" id="wlabel', glade)[0]
         if sys.platform == 'darwin':

--- a/setup.py
+++ b/setup.py
@@ -64,18 +64,18 @@ if sys.platform == 'darwin':
     from py2app.util import PY_SUFFIXES
     PY_SUFFIXES.append('')
 
-elif sys.platform == 'win32':
-    from cx_Freeze import setup, Executable
+#elif sys.platform == 'win32':
+    #from cx_Freeze import setup, Executable
 
     # Change base to 'Console' for debugging
-    e = Executable(app, base = 'Win32GUI', icon = 'images/FAHControl.ico')
-    options = {
-        'build_exe': {
-            'build_exe': 'gui',
-            #'includes': 'gtk',
-            }
-        }
-    extra_opts = dict(executables = [e], options = options)
+    #e = Executable(app, base = 'Win32GUI', icon = 'images/FAHControl.ico')
+    #options = {
+    #    'build_exe': {
+    #        'build_exe': 'gui',
+    #        #'includes': 'gtk',
+    #        }
+    #    }
+    #extra_opts = dict(executables = [e], options = options)
 
 else:
     from setuptools import setup, find_packages

--- a/setup.py
+++ b/setup.py
@@ -16,8 +16,8 @@ if os.path.exists(in_file):
     input = None
     output = None
     try:
-        input = open(in_file, 'r')
-        output = open(out_file, 'w')
+        input = open(in_file, 'r', encoding = "utf8")
+        output = open(out_file, 'w', encoding = "utf8")
 
         output.write('# -*- coding: utf8 -*-\n\n')
         output.write('glade_data = """')
@@ -89,12 +89,12 @@ else:
         )
 
 try:
-    version = open('version.txt').read().strip()
+    version = open('version.txt', encoding = "utf8").read().strip()
     version.split('.')
 except: version = '0.0.0'
 
 if not os.path.exists('fah/Version.py') or version != '0.0.0':
-    open('fah/Version.py', 'w').write('version = \'%s\'\n' % version)
+    open('fah/Version.py', 'w', encoding = "utf8").write('version = \'%s\'\n' % version)
 
 description = \
 '''Folding@home is a distributed computing project using volunteered
@@ -124,5 +124,5 @@ setup(
     **extra_opts)
 
 if sys.platform == 'darwin':
-    with open('package-description.txt', 'w') as f:
+    with open('package-description.txt', 'w', encoding = "utf8") as f:
         f.write(short_description.strip())

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ elif sys.platform == 'win32':
     options = {
         'build_exe': {
             'build_exe': 'gui',
-            'includes': 'gtk'
+            #'includes': 'gtk',
             }
         }
     extra_opts = dict(executables = [e], options = options)


### PR DESCRIPTION
I spend some time looking into the build on Windows 10. Note that I have no experience with Python3 packaging and GTK on Windows.

Good news first: I was able to create a binary that can be started without having to install anything. On the first glance it looked complete, but I didn't test everything.

I'm writing this PR to document my results, so that someone else can continue from here on.

In my description I'm using PyInstaller with the command `pyinstaller FAHControl --windowed`. This has two issues:

  - I could not get `pyinstaller FAHControl --onefile --windowed` to work, which would be easier to distribute. When I try to start the exe I get the error `gi/_gi-cpython-38.dll could not be extracted!`
  - This is a manual invocation, I have not integrated this in `setup.py` as it looks a bit complicated looking at https://github.com/pyinstaller/pyinstaller/wiki/Recipe-Setuptools-Entry-Point and https://stackoverflow.com/questions/48884766/pyinstaller-on-a-setuptools-package

Before I tried PyInstaller I tried cx_Freeze, but encountered several issues in the current published versions:

  - With cx_Freeze installed via pip I encountered this issue: https://github.com/anthony-tuininga/cx_Freeze/issues/596
  - As suggested in that issue I uninstalled cx_Freeze via pip and installed the mingw variant via `pacman -S mingw-w64-x86_64-python3-cx_Freeze`, however that fails with `error: [Errno 2] No such file or directory: 'C:/msys64/mingw64/tcl/tcl8.6'`
  - I tried to set TCL_LIBRARY and TK_LIBRARY paths, but then had the issue https://github.com/anthony-tuininga/cx_Freeze/issues/566 I did not try out the suggested workaround to copy the files manually, might be worth to look into
  - I completely excluded tcl/tk just to see if everything else would work but then was stopped by something wrong with sqlite3...

As an alternative to MSYS2 / mingw I tried out the usual windows python installation and to install gtk via vcpkg packages as suggested in https://www.gtk.org/docs/installations/windows/#using-gtk-from-vcpkg-packages I think this also required to install "Build Tools for Visual Studio 2019".
Unfortunately I think I was too inexperienced with all of this, as I failed to tell `pip install PyGObject` where to find the libraries / header files.